### PR TITLE
Fixing q643 q644

### DIFF
--- a/2018/python/lar_constraints.py
+++ b/2018/python/lar_constraints.py
@@ -981,36 +981,6 @@ class lar_constraints(object):
 				row["aus_result_"+str(i+1)] = random.choice(result_enums[:-1])
 		return row
 
-	def v697_const(self, row): 
-		"""1) If Automated Underwriting System: 1, Automated Underwriting System: 2; Automated Underwriting
-			System: 3; Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 1,
-			then the corresponding Automated Underwriting System Result: 1; Automated Underwriting System Result: 2;
-			Automated Underwriting System Result: 3; Automated Underwriting System Result: 4; or
-			Automated Underwriting System Result: 5 must equal 1, 2, 3, 4, 5, 6, or 7."""
-		aus_sys = [row["aus_1"], row["aus_2"], row["aus_3"], row["aus_4"], row["aus_5"]]
-		aus_results = [row["aus_result_1"], row["aus_result_2"], row["aus_result_3"], row["aus_result_4"], row["aus_result_5"]]
-
-		for i in range(len(aus_sys)):
-			if aus_sys[i] == "1":
-				if aus_results[i] not in ("1", "2", "3", "4", "5", "6", "7"):
-					row["aus_result_"+str(i+1)] = random.choice(("1", "2", "3", "4", "5", "6", "7"))
-		return row
-
-	def v698_const(self, row): 
-		"""1) If Automated Underwriting System: 1; Automated Underwriting System: 2; Automated Underwriting
-			System: 3; Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 2, then the
-			corresponding Automated Underwriting System Result: 1; Automated Underwriting System Result: 2;
-			Automated Underwriting System Result: 3; Automated Underwriting System Result: 4; or
-			Automated Underwriting System Result: 5 must equal 8, 9, 10, 11, or 12."""
-		aus_sys = [row["aus_1"], row["aus_2"], row["aus_3"], row["aus_4"], row["aus_5"]]
-		aus_results = [row["aus_result_1"], row["aus_result_2"], row["aus_result_3"], row["aus_result_4"], row["aus_result_5"]]
-
-		for i in range(len(aus_sys)):
-			if aus_sys[i] == "2":
-				if aus_results[i] not in ("8","9", "10", "11", "12"):
-					row["aus_result_"+str(i+1)] = random.choice(("8","9", "10", "11", "12"))
-		return row
-
 	def v699_const(self, row): 
 		"""1) If Automated Underwriting System: 1; Automated Underwriting System: 2; Automated Underwriting
 			System: 3; Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 5,

--- a/2018/python/rules_engine.py
+++ b/2018/python/rules_engine.py
@@ -2418,40 +2418,6 @@ class rules_engine(object):
 			vals_2=vals_2),axis=1)==False)]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
-	def v697(self):
-		"""An invalid Automated Underwriting System data field was reported.
-		1) If Automated Underwriting System: 1, Automated Underwriting System: 2;
-		Automated Underwriting System: 3; Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 1,
-		then the corresponding Automated Underwriting System Result: 1; Automated Underwriting System Result: 2;
-		Automated Underwriting System Result: 3; Automated Underwriting System Result: 4; or
-		Automated Underwriting System Result: 5 must equal 1, 2, 3, 4, 5, 6, or 7."""
-		field = "AUS and Results"
-		edit_name = "v697"
-		aus_results = ("1", "2", "3", "4", "5", "6", "7")
-		fail_df = self.lar_df[((self.lar_df.aus_1=="1")&(~self.lar_df.aus_result_1.isin(aus_results)))|
-			((self.lar_df.aus_2=="1")&(~self.lar_df.aus_result_2.isin(aus_results)))|
-			((self.lar_df.aus_3=="1")&(~self.lar_df.aus_result_3.isin(aus_results)))|
-			((self.lar_df.aus_4=="1")&(~self.lar_df.aus_result_4.isin(aus_results)))|
-			((self.lar_df.aus_5=="1")&(~self.lar_df.aus_result_5.isin(aus_results)))]
-		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
-
-	def v698(self):
-		"""An invalid Automated Underwriting System data field was reported.
-		1) If Automated Underwriting System: 1; Automated Underwriting System: 2; Automated Underwriting System: 3;
-		Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 2,
-		then the corresponding Automated Underwriting System Result: 1; Automated Underwriting System Result: 2;
-		Automated Underwriting System Result: 3; Automated Underwriting System Result: 4; or Automated Underwriting System Result: 5
-		must equal 8, 9, 10, 11, or 12."""
-		field = "AUS and Results"
-		edit_name = "v698"
-		aus_results = ("8", "9", "10", "11", "12")
-		fail_df = self.lar_df[((self.lar_df.aus_1=="2")&(~self.lar_df.aus_result_1.isin(aus_results)))|
-			((self.lar_df.aus_2=="2")&(~self.lar_df.aus_result_2.isin(aus_results)))|
-			((self.lar_df.aus_3=="2")&(~self.lar_df.aus_result_3.isin(aus_results)))|
-			((self.lar_df.aus_4=="2")&(~self.lar_df.aus_result_4.isin(aus_results)))|
-			((self.lar_df.aus_5=="2")&(~self.lar_df.aus_result_5.isin(aus_results)))]
-		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
-
 	def v699(self):
 		"""An invalid Automated Underwriting System data field was reported.
 		1) If Automated Underwriting System: 1; Automated Underwriting System: 2; Automated Underwriting System: 3;

--- a/2019/python/lar_constraints.py
+++ b/2019/python/lar_constraints.py
@@ -1011,36 +1011,6 @@ class lar_constraints(object):
 
 		return row
 
-	def v697_const(self, row): 
-		"""1) If Automated Underwriting System: 1, Automated Underwriting System: 2; Automated Underwriting
-			System: 3; Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 1,
-			then the corresponding Automated Underwriting System Result: 1; Automated Underwriting System Result: 2;
-			Automated Underwriting System Result: 3; Automated Underwriting System Result: 4; or
-			Automated Underwriting System Result: 5 must equal 1, 2, 3, 4, 5, 6, or 7."""
-		aus_sys = [row["aus_1"], row["aus_2"], row["aus_3"], row["aus_4"], row["aus_5"]]
-		aus_results = [row["aus_result_1"], row["aus_result_2"], row["aus_result_3"], row["aus_result_4"], row["aus_result_5"]]
-
-		for i in range(len(aus_sys)):
-			if aus_sys[i] == "1":
-				if aus_results[i] not in ("1", "2", "3", "4", "5", "6", "7"):
-					row["aus_result_"+str(i+1)] = random.choice(("1", "2", "3", "4", "5", "6", "7"))
-		return row
-
-	def v698_const(self, row): 
-		"""1) If Automated Underwriting System: 1; Automated Underwriting System: 2; Automated Underwriting
-			System: 3; Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 2, then the
-			corresponding Automated Underwriting System Result: 1; Automated Underwriting System Result: 2;
-			Automated Underwriting System Result: 3; Automated Underwriting System Result: 4; or
-			Automated Underwriting System Result: 5 must equal 8, 9, 10, 11, or 12."""
-		aus_sys = [row["aus_1"], row["aus_2"], row["aus_3"], row["aus_4"], row["aus_5"]]
-		aus_results = [row["aus_result_1"], row["aus_result_2"], row["aus_result_3"], row["aus_result_4"], row["aus_result_5"]]
-
-		for i in range(len(aus_sys)):
-			if aus_sys[i] == "2":
-				if aus_results[i] not in ("8","9", "10", "11", "12"):
-					row["aus_result_"+str(i+1)] = random.choice(("8","9", "10", "11", "12"))
-		return row
-
 	def v699_const(self, row): 
 		"""1) If Automated Underwriting System: 1; Automated Underwriting System: 2; Automated Underwriting
 			System: 3; Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 5,

--- a/2019/python/rules_engine.py
+++ b/2019/python/rules_engine.py
@@ -2422,40 +2422,6 @@ class rules_engine(object):
 			vals_2=vals_2),axis=1)==False)]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
-	def v697(self):
-		"""An invalid Automated Underwriting System data field was reported.
-		1) If Automated Underwriting System: 1, Automated Underwriting System: 2;
-		Automated Underwriting System: 3; Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 1,
-		then the corresponding Automated Underwriting System Result: 1; Automated Underwriting System Result: 2;
-		Automated Underwriting System Result: 3; Automated Underwriting System Result: 4; or
-		Automated Underwriting System Result: 5 must equal 1, 2, 3, 4, 5, 6, or 7."""
-		field = "AUS and Results"
-		edit_name = "v697"
-		aus_results = ("1", "2", "3", "4", "5", "6", "7")
-		fail_df = self.lar_df[((self.lar_df.aus_1=="1")&(~self.lar_df.aus_result_1.isin(aus_results)))|
-			((self.lar_df.aus_2=="1")&(~self.lar_df.aus_result_2.isin(aus_results)))|
-			((self.lar_df.aus_3=="1")&(~self.lar_df.aus_result_3.isin(aus_results)))|
-			((self.lar_df.aus_4=="1")&(~self.lar_df.aus_result_4.isin(aus_results)))|
-			((self.lar_df.aus_5=="1")&(~self.lar_df.aus_result_5.isin(aus_results)))]
-		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
-
-	def v698(self):
-		"""An invalid Automated Underwriting System data field was reported.
-		1) If Automated Underwriting System: 1; Automated Underwriting System: 2; Automated Underwriting System: 3;
-		Automated Underwriting System: 4; or Automated Underwriting System: 5 equals 2,
-		then the corresponding Automated Underwriting System Result: 1; Automated Underwriting System Result: 2;
-		Automated Underwriting System Result: 3; Automated Underwriting System Result: 4; or Automated Underwriting System Result: 5
-		must equal 8, 9, 10, 11, or 12."""
-		field = "AUS and Results"
-		edit_name = "v698"
-		aus_results = ("8", "9", "10", "11", "12")
-		fail_df = self.lar_df[((self.lar_df.aus_1=="2")&(~self.lar_df.aus_result_1.isin(aus_results)))|
-			((self.lar_df.aus_2=="2")&(~self.lar_df.aus_result_2.isin(aus_results)))|
-			((self.lar_df.aus_3=="2")&(~self.lar_df.aus_result_3.isin(aus_results)))|
-			((self.lar_df.aus_4=="2")&(~self.lar_df.aus_result_4.isin(aus_results)))|
-			((self.lar_df.aus_5=="2")&(~self.lar_df.aus_result_5.isin(aus_results)))]
-		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
-
 	def v699(self):
 		"""
 		If Automated Underwriting System: 1; Automated


### PR DESCRIPTION
Close #724 and Close #725 

V697 and V698 were removed from the 2018 FIG and converted to Q643 and Q644. Removing these edits would allow the Q643 and Q644 quality test files to pass syntax and validity edits. 