### PR TITLE
removing v630_2 edit

### DIFF
--- a/2018/python/lar_constraints.py
+++ b/2018/python/lar_constraints.py
@@ -192,12 +192,9 @@ class lar_constraints(object):
 	def v630_const(self, row):
 		"""1) If Ethnicity of Applicant or Borrower: 1 equals 4, then Ethnicity of Applicant or Borrower Collected on the Basis of Visual Observation or Surname 
 			must equal 3.
-		2) If Ethnicity of Applicant or Borrower Collected on the Basis of Visual Observation or Surname equals 3, then Ethnicity of Applicant or Borrower: 1 
-			must equal 3 or 4."""
+		"""
 		if row["app_eth_1"] == "4":
 			row["app_eth_basis"] = "3"
-		if row["app_eth_basis"] == "3" and row["app_eth_1"] not in ("3", "4"):
-			row["app_eth_1"] = random.choice(("3", "4"))
 		return row
 
 	def v631_1_const(self, row):

--- a/2018/python/lar_constraints.py
+++ b/2018/python/lar_constraints.py
@@ -130,11 +130,13 @@ class lar_constraints(object):
 		"""1) Ethnicity of Applicant or Borrower: 1 must equal 1, 11, 12, 13, 14, 2, 3, or 4, and cannot be left blank,
 			   unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other
 			   Hispanic or Latino."""
-		eth_enums = ["1", "11", "12", "13", "14", "2", "3", "4"]
+		eth_enums = ["1", "11", "12", "13", "2", "3", "4"]
 		if row["app_eth_free"] == "" and row["app_eth_1"] not in eth_enums:
 			row["app_eth_1"] = random.choice(eth_enums)
 		if row["app_eth_free"] != "" and row["app_eth_1"] in eth_enums:
-			row["app_eth_free"] = ''
+			row["app_eth_free"] = ""
+		if (row["app_eth_1"] in ["14", ""]):
+			row["app_eth_free"] = utils.char_string_gen(random.choice(range(100)))
 		return row
 
 	def v628_2_const(self, row):

--- a/2018/python/lar_constraints.py
+++ b/2018/python/lar_constraints.py
@@ -1,5 +1,6 @@
 import random
 import string
+import utils
 
 class lar_constraints(object):
 
@@ -130,8 +131,10 @@ class lar_constraints(object):
 			   unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other
 			   Hispanic or Latino."""
 		eth_enums = ["1", "11", "12", "13", "14", "2", "3", "4"]
-		if row["app_eth_1"] =="" and row["app_eth_free"] =="":
+		if row["app_eth_free"] == "" and row["app_eth_1"] not in eth_enums:
 			row["app_eth_1"] = random.choice(eth_enums)
+		if row["app_eth_free"] != "" and row["app_eth_1"] in eth_enums:
+			row["app_eth_free"] = ''
 		return row
 
 	def v628_2_const(self, row):

--- a/2018/python/lar_constraints.py
+++ b/2018/python/lar_constraints.py
@@ -129,7 +129,16 @@ class lar_constraints(object):
 	def v628_1_const(self, row):
 		"""1) Ethnicity of Applicant or Borrower: 1 must equal 1, 11, 12, 13, 14, 2, 3, or 4, and cannot be left blank,
 			   unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other
-			   Hispanic or Latino."""
+			   Hispanic or Latino.
+			   
+			Note: Changes to LAR constraint v628_1 were necessary to remove edit v630_2. 
+			Removing edit v630_2 from the LAR constraints allowed more randomization in 
+			the value for Applicant Ethnicity 1, and caused the program to stall. 
+			This behavior exposed a flaw in LAR constraint v628_1. 
+			Originally, V628_1 did not include a contrapositive condition in the constraint, 
+			which when removing v630_2, caused the program to take a prohibitively longer time 
+			to validate the correct ethnicity codes.
+		"""
 		eth_enums = ["1", "11", "12", "13", "2", "3", "4"]
 		if row["app_eth_free"] == "" and row["app_eth_1"] not in eth_enums:
 			row["app_eth_1"] = random.choice(eth_enums)

--- a/2018/python/rules_engine.py
+++ b/2018/python/rules_engine.py
@@ -694,21 +694,13 @@ class rules_engine(object):
 		fail_df = self.lar_df[(self.lar_df.app_eth_basis=="2")&(~self.lar_df.app_eth_1.isin(("1", "11", "12", "13", "14", "2", "3")))]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
-	def v630_1(self):
+	def v630(self):
 		"""An invalid Ethnicity data field was reported.
-		1) If Ethnicity of Applicant or Borrower: 1 equals 4, then Ethnicity of Applicant or Borrower Collected on the Basis of Visual Observation or Surname must equal 3."""
+		1) If Ethnicity of Applicant or Borrower: 1 equals 4, then Ethnicity of Applicant or Borrower 
+		Collected on the Basis of Visual Observation or Surname must equal 3."""
 		field = "app ethnicity basis"
 		edit_name = "v630_1"
 		fail_df = self.lar_df[(self.lar_df.app_eth_basis!="3")&(self.lar_df.app_eth_1=="4")]
-		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
-
-	def v630_2(self):
-		"""An invalid Ethnicity data field was reported.
-		2) If Ethnicity of Applicant or Borrower Collected on the Basis of Visual Observation or Surname equals 3, then 
-		Ethnicity of Applicant or Borrower: 1 must equal 3 or 4."""
-		field = "app ethnicity basis"
-		edit_name = "v630_2"
-		fail_df = self.lar_df[(self.lar_df.app_eth_basis=="3")&(~self.lar_df.app_eth_1.isin(("3","4")))]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
 

--- a/2018/python/rules_engine.py
+++ b/2018/python/rules_engine.py
@@ -635,10 +635,11 @@ class rules_engine(object):
 		unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other Hispanic or Latino."""
 		field = "app_eth_1"
 		edit_name = "v628_1"
-		fail_df = self.lar_df[((~self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4"))) & 
+		fail_df = self.lar_df[((~self.lar_df.app_eth_1.isin(("1","11", "12", "13", "2", "3","4"))) & 
 								(self.lar_df.app_eth_free == ''))|
-							  ((self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4"))) & 
-								(self.lar_df.app_eth_free != ''))]
+							  ((self.lar_df.app_eth_1.isin(("1","11", "12", "13", "2", "3","4"))) & 
+								(self.lar_df.app_eth_free != ''))|
+							  ((self.lar_df.app_eth_1.isin(("14",""))) & (self.lar_df.app_eth_free == ''))]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
 	def v628_2(self):

--- a/2018/python/rules_engine.py
+++ b/2018/python/rules_engine.py
@@ -637,9 +637,8 @@ class rules_engine(object):
 		edit_name = "v628_1"
 		fail_df = self.lar_df[((~self.lar_df.app_eth_1.isin(("1","11", "12", "13", "2", "3","4"))) & 
 								(self.lar_df.app_eth_free == ''))|
-							  ((self.lar_df.app_eth_1.isin(("1","11", "12", "13", "2", "3","4"))) & 
-								(self.lar_df.app_eth_free != ''))|
-							  ((self.lar_df.app_eth_1.isin(("14",""))) & (self.lar_df.app_eth_free == ''))]
+							  ((self.lar_df.app_eth_1 == '') & 
+							  	(self.lar_df.app_eth_free == ''))]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
 	def v628_2(self):

--- a/2018/python/rules_engine.py
+++ b/2018/python/rules_engine.py
@@ -635,7 +635,10 @@ class rules_engine(object):
 		unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other Hispanic or Latino."""
 		field = "app_eth_1"
 		edit_name = "v628_1"
-		fail_df = self.lar_df[~(self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4")))|((self.lar_df.app_eth_free=="")&(self.lar_df.app_eth_1==""))]
+		fail_df = self.lar_df[((~self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4"))) & 
+								(self.lar_df.app_eth_free == ''))|
+							  ((self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4"))) & 
+								(self.lar_df.app_eth_free != ''))]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
 	def v628_2(self):
@@ -696,13 +699,11 @@ class rules_engine(object):
 
 	def v630(self):
 		"""An invalid Ethnicity data field was reported.
-		1) If Ethnicity of Applicant or Borrower: 1 equals 4, then Ethnicity of Applicant or Borrower 
-		Collected on the Basis of Visual Observation or Surname must equal 3."""
+		1) If Ethnicity of Applicant or Borrower: 1 equals 4, then Ethnicity of Applicant or Borrower Collected on the Basis of Visual Observation or Surname must equal 3."""
 		field = "app ethnicity basis"
 		edit_name = "v630_1"
 		fail_df = self.lar_df[(self.lar_df.app_eth_basis!="3")&(self.lar_df.app_eth_1=="4")]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
-
 
 	def v631_1(self):
 		"""An invalid Ethnicity data field was reported.

--- a/2019/python/lar_constraints.py
+++ b/2019/python/lar_constraints.py
@@ -1,5 +1,6 @@
 import random
 import string
+import utils
 
 class lar_constraints(object):
 
@@ -129,11 +130,13 @@ class lar_constraints(object):
 		"""1) Ethnicity of Applicant or Borrower: 1 must equal 1, 11, 12, 13, 14, 2, 3, or 4, and cannot be left blank,
 			   unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other
 			   Hispanic or Latino."""
-		eth_enums = ["1", "11", "12", "13", "14", "2", "3", "4"]
+		eth_enums = ["1", "11", "12", "13", "2", "3", "4"]
 		if row["app_eth_free"] == "" and row["app_eth_1"] not in eth_enums:
 			row["app_eth_1"] = random.choice(eth_enums)
 		if row["app_eth_free"] != "" and row["app_eth_1"] in eth_enums:
-			row["app_eth_free"] = ''
+			row["app_eth_free"] = ""
+		if (row["app_eth_1"] in ["14", ""]):
+			row["app_eth_free"] = utils.char_string_gen(random.choice(range(100)))
 		return row
 
 	def v628_2_const(self, row):

--- a/2019/python/lar_constraints.py
+++ b/2019/python/lar_constraints.py
@@ -192,12 +192,9 @@ class lar_constraints(object):
 	def v630_const(self, row):
 		"""1) If Ethnicity of Applicant or Borrower: 1 equals 4, then Ethnicity of Applicant or Borrower Collected on the Basis of Visual Observation or Surname 
 			must equal 3.
-		2) If Ethnicity of Applicant or Borrower Collected on the Basis of Visual Observation or Surname equals 3, then Ethnicity of Applicant or Borrower: 1 
-			must equal 3 or 4."""
+		"""
 		if row["app_eth_1"] == "4":
 			row["app_eth_basis"] = "3"
-		if row["app_eth_basis"] == "3" and row["app_eth_1"] not in ("3", "4"):
-			row["app_eth_1"] = random.choice(("3", "4"))
 		return row
 
 	def v631_1_const(self, row):

--- a/2019/python/lar_constraints.py
+++ b/2019/python/lar_constraints.py
@@ -129,7 +129,16 @@ class lar_constraints(object):
 	def v628_1_const(self, row):
 		"""1) Ethnicity of Applicant or Borrower: 1 must equal 1, 11, 12, 13, 14, 2, 3, or 4, and cannot be left blank,
 			   unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other
-			   Hispanic or Latino."""
+			   Hispanic or Latino.
+			   
+			Note: Changes to LAR constraint v628_1 were necessary to remove edit v630_2. 
+			Removing edit v630_2 from the LAR constraints allowed more randomization in 
+			the value for Applicant Ethnicity 1, and caused the program to stall. 
+			This behavior exposed a flaw in LAR constraint v628_1. 
+			Originally, V628_1 did not include a contrapositive condition in the constraint, 
+			which when removing v630_2, caused the program to take a prohibitively longer time 
+			to validate the correct ethnicity codes.
+		"""
 		eth_enums = ["1", "11", "12", "13", "2", "3", "4"]
 		if row["app_eth_free"] == "" and row["app_eth_1"] not in eth_enums:
 			row["app_eth_1"] = random.choice(eth_enums)

--- a/2019/python/lar_constraints.py
+++ b/2019/python/lar_constraints.py
@@ -130,8 +130,10 @@ class lar_constraints(object):
 			   unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other
 			   Hispanic or Latino."""
 		eth_enums = ["1", "11", "12", "13", "14", "2", "3", "4"]
-		if row["app_eth_1"] =="" and row["app_eth_free"] =="":
+		if row["app_eth_free"] == "" and row["app_eth_1"] not in eth_enums:
 			row["app_eth_1"] = random.choice(eth_enums)
+		if row["app_eth_free"] != "" and row["app_eth_1"] in eth_enums:
+			row["app_eth_free"] = ''
 		return row
 
 	def v628_2_const(self, row):

--- a/2019/python/rules_engine.py
+++ b/2019/python/rules_engine.py
@@ -694,23 +694,14 @@ class rules_engine(object):
 		fail_df = self.lar_df[(self.lar_df.app_eth_basis=="2")&(~self.lar_df.app_eth_1.isin(("1", "11", "12", "13", "14", "2", "3")))]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
-	def v630_1(self):
+	def v630(self):
 		"""An invalid Ethnicity data field was reported.
-		1) If Ethnicity of Applicant or Borrower: 1 equals 4, then Ethnicity of Applicant or Borrower Collected on the Basis of Visual Observation or Surname must equal 3."""
+		1) If Ethnicity of Applicant or Borrower: 1 equals 4, then Ethnicity of Applicant or Borrower 
+		Collected on the Basis of Visual Observation or Surname must equal 3."""
 		field = "app ethnicity basis"
 		edit_name = "v630_1"
 		fail_df = self.lar_df[(self.lar_df.app_eth_basis!="3")&(self.lar_df.app_eth_1=="4")]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
-
-	def v630_2(self):
-		"""An invalid Ethnicity data field was reported.
-		2) If Ethnicity of Applicant or Borrower Collected on the Basis of Visual Observation or Surname equals 3, then 
-		Ethnicity of Applicant or Borrower: 1 must equal 3 or 4."""
-		field = "app ethnicity basis"
-		edit_name = "v630_2"
-		fail_df = self.lar_df[(self.lar_df.app_eth_basis=="3")&(~self.lar_df.app_eth_1.isin(("3","4")))]
-		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
-
 
 	def v631_1(self):
 		"""An invalid Ethnicity data field was reported.

--- a/2019/python/rules_engine.py
+++ b/2019/python/rules_engine.py
@@ -635,10 +635,11 @@ class rules_engine(object):
 		unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other Hispanic or Latino."""
 		field = "app_eth_1"
 		edit_name = "v628_1"
-		fail_df = self.lar_df[((~self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4"))) & 
+		fail_df = self.lar_df[((~self.lar_df.app_eth_1.isin(("1","11", "12", "13", "2", "3","4"))) & 
 								(self.lar_df.app_eth_free == ''))|
-							  ((self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4"))) & 
-								(self.lar_df.app_eth_free != ''))]
+							  ((self.lar_df.app_eth_1.isin(("1","11", "12", "13", "2", "3","4"))) & 
+								(self.lar_df.app_eth_free != ''))|
+							  ((self.lar_df.app_eth_1.isin(("14",""))) & (self.lar_df.app_eth_free == ''))]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
 	def v628_2(self):

--- a/2019/python/rules_engine.py
+++ b/2019/python/rules_engine.py
@@ -635,7 +635,10 @@ class rules_engine(object):
 		unless an ethnicity is provided in Ethnicity of Applicant or Borrower: Free Form Text Field for Other Hispanic or Latino."""
 		field = "app_eth_1"
 		edit_name = "v628_1"
-		fail_df = self.lar_df[~(self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4")))|((self.lar_df.app_eth_free=="")&(self.lar_df.app_eth_1==""))]
+		fail_df = self.lar_df[((~self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4"))) & 
+								(self.lar_df.app_eth_free == ''))|
+							  ((self.lar_df.app_eth_1.isin(("1","11", "12", "13", "14", "2", "3","4"))) & 
+								(self.lar_df.app_eth_free != ''))]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
 	def v628_2(self):

--- a/2019/python/rules_engine.py
+++ b/2019/python/rules_engine.py
@@ -637,9 +637,8 @@ class rules_engine(object):
 		edit_name = "v628_1"
 		fail_df = self.lar_df[((~self.lar_df.app_eth_1.isin(("1","11", "12", "13", "2", "3","4"))) & 
 								(self.lar_df.app_eth_free == ''))|
-							  ((self.lar_df.app_eth_1.isin(("1","11", "12", "13", "2", "3","4"))) & 
-								(self.lar_df.app_eth_free != ''))|
-							  ((self.lar_df.app_eth_1.isin(("14",""))) & (self.lar_df.app_eth_free == ''))]
+							  ((self.lar_df.app_eth_1 == '') & 
+							  	(self.lar_df.app_eth_free == ''))]
 		self.results_wrapper(edit_name=edit_name, field_name=field, fail_df=fail_df)
 
 	def v628_2(self):


### PR DESCRIPTION
Close #733 

Note: Changes to LAR constraint v628_1 were necessary to remove edit v630_2. Removing edit v630_2 from the LAR constraints allowed more randomization in the value for Applicant Ethnicity 1, and caused the program to stall. This behavior exposed a flaw in LAR constraint v628_1. Originally, V628_1 did not include a contrapositive condition in the constraint, which when removing v630_2, caused the program to take a prohibitively longer time to validate the correct ethnicity codes.